### PR TITLE
Allow single word comments to be added to debloat list

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -88,6 +88,9 @@ if [ -f $DebloatListFile ]
 then
 	# Source the input file
 	. $DebloatListFile
+
+	# Strip out one word comments (allows easier grouping)
+	DebloatList=$(echo $DebloatList | tr ' ' '\n' | grep -v '#' | xargs echo)
 else
 	# Log error
 	LogLine='Input file not found, creating a template file!'																					   

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=SystemlessDebloater
 name=Systemless Debloater (REPLACE)
-version=1.4.8
+version=1.4.9
 versionCode=148
 author=zgfg @ xda
 


### PR DESCRIPTION
Hello!

Love the script but wanted a way to group things (since Samsung installs a LOT of junk on their devices) and this change allows me to group like the following example:

```
DebloatList="
#Bixby
BixbyService
BixbySystemUI

#Calendar
SamsungCalendar
GoogleCalendar
"
```

It's not 100% ideal since it doesn't allow spaces in the comments but it's better than nothing and helps me keep on top of what weird package names tie to which functionality I'm removing. :)

Thanks!