### PR TITLE
Fix regex

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -115,7 +115,7 @@ then
 
 	# Clean the config file format and save to a temporary file
 	TmpConfigFile=$MODPATH/TmpSystemlessDebloater.cfg
-	sed -e '/^#/d' -e 's/#.*//g' -e 's/\"//g' -e 's/[ \t ]//g' -e '/^\s*$/d' $ConfigFile > $TmpConfigFile
+	sed -e '/^#/d' -e 's/#.*//g' -e 's/\"//g' -e 's/[ \t ]//g' -e '/^$/d' $ConfigFile > $TmpConfigFile
 
 	# Append new line to the temporary config if not present
 	if [ -n "$(tail -c1 $TmpConfigFile)" ]


### PR DESCRIPTION
Due to update in Magisk's BusyBox.
_BusyBox v1.36.1-Magisk (2023-09-02 05:30:11 PDT) multi-call binary._

The current Magisk ```sed``` errors out when generating the "$TmpConfigFile"
```sed: bad regex '^\s*$': trailing backslash (\)```
Resulting in an empty "$TmpConfigFile".

This fix correct the regex when importing the user config file.
_The ```\s*``` is not need._
